### PR TITLE
Fix googlexs

### DIFF
--- a/.github/workflows/googleXs.yml
+++ b/.github/workflows/googleXs.yml
@@ -42,7 +42,7 @@ jobs:
     # Configure Docker to use the gcloud command-line tool as a credential
     # helper for authentication
     - run: |-
-    gcloud --quiet auth configure-docker
+        gcloud --quiet auth configure-docker
 
     - name: DefenseCode ThunderScan Action
       uses: defensecode/thunderscan-action@v1.0

--- a/.github/workflows/googleXs.yml
+++ b/.github/workflows/googleXs.yml
@@ -44,10 +44,6 @@ jobs:
     - run: |-
         gcloud --quiet auth configure-docker
 
-    - name: DefenseCode ThunderScan Action
-      uses: defensecode/thunderscan-action@v1.0
-
-
     # Get the GKE credentials so we can deploy to the cluster
     - uses: google-github-actions/get-gke-credentials@v2.2.1
       with:


### PR DESCRIPTION
defensecode/thunderscan-action requires an input (and software) and as such this step does nothing (beyond adding a dependency to your workflow)